### PR TITLE
fix: turn ArcoLinux logo text into path

### DIFF
--- a/assets/img/arcolinux-logo.svg
+++ b/assets/img/arcolinux-logo.svg
@@ -72,13 +72,13 @@
      inkscape:window-height="697"
      id="namedview4"
      showgrid="false"
-     inkscape:zoom="0.091138648"
-     inkscape:cx="2380.9877"
-     inkscape:cy="378.54413"
+     inkscape:zoom="0.064444756"
+     inkscape:cx="543.10082"
+     inkscape:cy="1668.0954"
      inkscape:window-x="10"
      inkscape:window-y="55"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2"
+     inkscape:current-layer="text3062"
      showguides="true"
      inkscape:guide-bbox="true"
      inkscape:pagecheckerboard="0">
@@ -97,24 +97,52 @@
      xml:space="preserve"
      id="text1890"
      style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect1892);fill:#000000;fill-opacity:1;stroke:none;letter-spacing:5px" />
-  <text
-     xml:space="preserve"
+  <g
+     aria-label="ARCO"
+     transform="translate(918.35738,218.07616)"
      id="text3062"
-     style="font-style:normal;font-weight:normal;font-size:600px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect3064);mix-blend-mode:normal;fill:#d4d4d4;fill-opacity:1;stroke:none;letter-spacing:20px"
-     transform="translate(918.35738,218.07616)"><tspan
-       x="1338.0469"
-       y="941.83008"
-       id="tspan41100"><tspan
-         style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
-         id="tspan41098">ARCO</tspan></tspan></text>
-  <text
-     xml:space="preserve"
+     style="font-size:600px;line-height:1.25;letter-spacing:20px;white-space:pre;shape-inside:url(#rect3064);fill:#d4d4d4">
+    <path
+       d="m 1658.5547,862.14258 h -176.3672 l -27.832,79.6875 h -113.3789 l 162.0117,-437.40235 h 134.4726 l 162.0118,437.40235 h -113.3789 z m -148.2422,-81.15235 h 119.8242 L 1570.3711,606.9668 Z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41117" />
+    <path
+       d="m 2037.7344,698.37305 q 35.4492,0 50.6836,-13.1836 15.5273,-13.18359 15.5273,-43.35937 0,-29.88281 -15.5273,-42.77344 -15.2344,-12.89062 -50.6836,-12.89062 h -47.461 v 112.20703 z m -47.461,77.92968 V 941.83008 H 1877.4805 V 504.42773 h 172.2656 q 86.4258,0 126.5625,29.00391 40.4297,29.00391 40.4297,91.69922 0,43.35937 -21.0938,71.19141 -20.8007,27.83203 -62.9882,41.01562 23.1445,5.27344 41.3085,24.02344 18.4571,18.45703 37.2071,56.25 l 61.2304,124.21875 h -120.1171 l -53.3204,-108.69141 q -16.1132,-32.8125 -32.8125,-44.82422 -16.4062,-12.01172 -43.9453,-12.01172 z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41119" />
+    <path
+       d="m 2706.3672,917.80664 q -31.0547,16.11328 -64.7461,24.31641 -33.6914,8.20312 -70.3125,8.20312 -109.2773,0 -173.1445,-60.9375 -63.8672,-61.23047 -63.8672,-165.82031 0,-104.88281 63.8672,-165.82031 63.8672,-61.23047 173.1445,-61.23047 36.6211,0 70.3125,8.20312 33.6914,8.20313 64.7461,24.31641 v 90.52734 q -31.3477,-21.38672 -61.8164,-31.34765 -30.4688,-9.96094 -64.1602,-9.96094 -60.3515,0 -94.9218,38.67187 -34.5704,38.67188 -34.5704,106.64063 0,67.67578 34.5704,106.34766 34.5703,38.67187 94.9218,38.67187 33.6914,0 64.1602,-9.96094 30.4687,-9.96093 61.8164,-31.34765 z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41121" />
+    <path
+       d="m 3019.6289,578.25586 q -51.5625,0 -79.9805,38.08594 -28.4179,38.08593 -28.4179,107.22656 0,68.84766 28.4179,106.93359 28.418,38.08594 79.9805,38.08594 51.8555,0 80.2734,-38.08594 28.418,-38.08593 28.418,-106.93359 0,-69.14063 -28.418,-107.22656 -28.4179,-38.08594 -80.2734,-38.08594 z m 0,-81.73828 q 105.4688,0 165.2344,60.35156 59.7656,60.35156 59.7656,166.69922 0,106.05469 -59.7656,166.40625 -59.7656,60.35156 -165.2344,60.35156 -105.1758,0 -165.2344,-60.35156 -59.7656,-60.35156 -59.7656,-166.40625 0,-106.34766 59.7656,-166.69922 60.0586,-60.35156 165.2344,-60.35156 z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41123" />
+  </g>
+  <g
+     aria-label="LINUX"
+     transform="translate(866.20894,735.08009)"
      id="text3062-6"
-     style="font-style:normal;font-weight:normal;font-size:600px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect3064-3);mix-blend-mode:normal;fill:#d4d4d4;fill-opacity:1;stroke:none;letter-spacing:20px"
-     transform="translate(866.20894,735.08009)"><tspan
-       x="1338.0469"
-       y="941.83008"
-       id="tspan41104"><tspan
-         style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
-         id="tspan41102">LINUX</tspan></tspan></text>
+     style="font-size:600px;line-height:1.25;letter-spacing:20px;white-space:pre;shape-inside:url(#rect3064-3);fill:#d4d4d4">
+    <path
+       d="m 1393.125,504.42773 h 112.793 v 352.14844 h 198.0468 v 85.25391 H 1393.125 Z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41106" />
+    <path
+       d="m 1795.4492,504.42773 h 112.793 v 437.40235 h -112.793 z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41108" />
+    <path
+       d="m 2038.6914,504.42773 h 125.9766 l 159.082,300 v -300 h 106.9336 V 941.83008 H 2304.707 l -159.082,-300 v 300 h -106.9336 z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41110" />
+    <path
+       d="m 2560.8398,504.42773 h 112.793 v 262.20704 q 0,54.19921 17.5781,77.63671 17.8711,23.14454 58.0079,23.14454 40.4296,0 58.0078,-23.14454 17.8711,-23.4375 17.8711,-77.63671 V 504.42773 h 112.7929 v 262.20704 q 0,92.87109 -46.582,138.28125 -46.582,45.41015 -142.0898,45.41015 -95.2149,0 -141.7969,-45.41015 -46.5821,-45.41016 -46.5821,-138.28125 z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41112" />
+    <path
+       d="m 3311.7969,718.58789 151.7578,223.24219 H 3346.0742 L 3243.8281,792.41602 3142.4609,941.83008 H 3024.3945 L 3176.1523,718.58789 3030.2539,504.42773 h 117.7734 l 95.8008,140.91797 95.5078,-140.91797 h 118.3594 z"
+       style="font-weight:bold;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+       id="path41114" />
+  </g>
 </svg>


### PR DESCRIPTION
In devices w/o DejaVu sans, the "ArcoLinux" text just shows up
as a serif font. This fixes it by turning the text into a path in Inkscape.

![arcolinux text](https://user-images.githubusercontent.com/39676098/142787709-51d334e2-d00b-49fb-8099-8a04e78c1fc4.png)